### PR TITLE
user_create

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,8 +35,9 @@ class UsersController < ApplicationController
 
   def create
     begin
+      nicknames_valid?
       @users = []
-      params["users"].each do |nickname|
+      params[:nicknames].each do |nickname|
         user = User.find_or_create_by!(nickname:)
         @users << user
       end
@@ -53,6 +54,16 @@ class UsersController < ApplicationController
 
 
   private
+
+  def nicknames_valid?
+    # Nicknames param must exist, and there must be between 3 and 10 players
+    if params[:nicknames].blank? || params[:nicknames].uniq.length < 3 || params[:nicknames].uniq.length > 10
+      raise ArgumentError, "#{params[:nicknames].blank? ? 0 : params[:nicknames].uniq.length } players provided, there must be 3..10 players"
+    # Nicknames param mustn't contain an empty ("") nickname
+    elsif params[:nicknames].include?("")
+      raise ArgumentError, "Nicknames provided contains an empty nickname"
+    end
+  end
 
   def user_params
     params.require(:user).permit(:nickname)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,6 +35,8 @@ class UsersController < ApplicationController
 
   def create
     begin
+      nicknames_exist?
+      set_nicknames
       nicknames_valid?
       @users = []
       params[:nicknames].each do |nickname|
@@ -55,13 +57,19 @@ class UsersController < ApplicationController
 
   private
 
+  def nicknames_exist?
+    raise ArgumentError, "No 'nicknames' key found in params" if params[:nicknames].blank?
+  end
+
+  def set_nicknames
+    # Removes empty nicknames and duplicates from params
+    params[:nicknames] = params[:nicknames].reject(&:empty?).uniq
+  end
+
   def nicknames_valid?
-    # Nicknames param must exist, and there must be between 3 and 10 players
-    if params[:nicknames].blank? || params[:nicknames].uniq.length < 3 || params[:nicknames].uniq.length > 10
-      raise ArgumentError, "#{params[:nicknames].blank? ? 0 : params[:nicknames].uniq.length } players provided, there must be 3..10 players"
-    # Nicknames param mustn't contain an empty ("") nickname
-    elsif params[:nicknames].include?("")
-      raise ArgumentError, "Nicknames provided contains an empty nickname"
+    # Ensures between 3 and 10 players were sent
+    if params[:nicknames].length < 3 || params[:nicknames].length > 10
+      raise ArgumentError, "#{params[:nicknames].length} players provided, there must be 3..10 players"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,6 +35,8 @@ class UsersController < ApplicationController
 
   def create
     begin
+      nicknames_exist?
+      set_nicknames
       nicknames_valid?
       @users = []
       params[:nicknames].each do |nickname|
@@ -55,13 +57,19 @@ class UsersController < ApplicationController
 
   private
 
+  def nicknames_exist?
+    raise ArgumentError, "No 'nicknames' key found in params" if params[:nicknames].blank?
+  end
+
+  def set_nicknames
+    # Removes empty nicknames and duplicates from params
+    params[:nicknames] = params[:nicknames].map(&:strip).reject(&:empty?).uniq
+  end
+
   def nicknames_valid?
-    # Nicknames param must exist, and there must be between 3 and 10 players
-    if params[:nicknames].blank? || params[:nicknames].uniq.length < 3 || params[:nicknames].uniq.length > 10
-      raise ArgumentError, "#{params[:nicknames].blank? ? 0 : params[:nicknames].uniq.length } players provided, there must be 3..10 players"
-    # Nicknames param mustn't contain an empty ("") nickname
-    elsif params[:nicknames].include?("")
-      raise ArgumentError, "Nicknames provided contains an empty nickname"
+    # Ensures between 3 and 10 players were sent
+    if params[:nicknames].length < 3 || params[:nicknames].length > 10
+      raise ArgumentError, "#{params[:nicknames].length} players provided, there must be 3..10 players"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,8 +35,6 @@ class UsersController < ApplicationController
 
   def create
     begin
-      nicknames_exist?
-      set_nicknames
       nicknames_valid?
       @users = []
       params[:nicknames].each do |nickname|
@@ -57,19 +55,13 @@ class UsersController < ApplicationController
 
   private
 
-  def nicknames_exist?
-    raise ArgumentError, "No 'nicknames' key found in params" if params[:nicknames].blank?
-  end
-
-  def set_nicknames
-    # Removes empty nicknames and duplicates from params
-    params[:nicknames] = params[:nicknames].map(&:strip).reject(&:empty?).uniq
-  end
-
   def nicknames_valid?
-    # Ensures between 3 and 10 players were sent
-    if params[:nicknames].length < 3 || params[:nicknames].length > 10
-      raise ArgumentError, "#{params[:nicknames].length} players provided, there must be 3..10 players"
+    # Nicknames param must exist, and there must be between 3 and 10 players
+    if params[:nicknames].blank? || params[:nicknames].uniq.length < 3 || params[:nicknames].uniq.length > 10
+      raise ArgumentError, "#{params[:nicknames].blank? ? 0 : params[:nicknames].uniq.length } players provided, there must be 3..10 players"
+    # Nicknames param mustn't contain an empty ("") nickname
+    elsif params[:nicknames].include?("")
+      raise ArgumentError, "Nicknames provided contains an empty nickname"
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,8 +35,10 @@ class UsersController < ApplicationController
 
   def create
     begin
+      @users = []
       params["users"].each do |nickname|
-        @user = User.create!(nickname:)
+        user = User.find_or_create_by!(nickname:)
+        @users << user
       end
     rescue => exception
       @errors = exception
@@ -45,7 +47,7 @@ class UsersController < ApplicationController
     if @errors
       render json: @errors, status: :unprocessable_entity
     else
-      render json: @user
+      render json: @users
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,7 +63,7 @@ class UsersController < ApplicationController
 
   def set_nicknames
     # Removes empty nicknames and duplicates from params
-    params[:nicknames] = params[:nicknames].reject(&:empty?).uniq
+    params[:nicknames] = params[:nicknames].map(&:strip).reject(&:empty?).uniq
   end
 
   def nicknames_valid?


### PR DESCRIPTION
users_controller#create modified:

- it now expects an array of nicknames for multiple user creation (a user won't play a match by himself, so no need for single user creation)
- if one of the nicknames passed matches an existing user in the db, users_controller#create will return this user instead of trying to create a new one.
- it now returns an array containing all the created (or found) users